### PR TITLE
Add Parallelisation Options to Detectors

### DIFF
--- a/src/classes/curved_detector.m
+++ b/src/classes/curved_detector.m
@@ -1,6 +1,6 @@
 classdef curved_detector < detector
     properties
-        init_to_source_vec (3, 1) double % The vector from the left edge of the detector to the source
+        init_source_pos    (3, 1) double % The initial position of the source
         source_position    (3, 1) double % The position of the source
         pixel_angle        (1, 1) double % The angle covered by each pixel
     end
@@ -19,14 +19,16 @@ classdef curved_detector < detector
             self.pixel_angle    = pixel_angle;
             
             % Only true for initial configuration
-            self.init_to_source_vec = rotz(-detector_angle/2) * self.to_source_vec; 
-            self.source_position    = self.to_source_vec * dist_to_detector/2;
+            self.init_source_pos    = self.to_source_vec * dist_to_detector/2; 
+            self.source_position    = self.init_source_pos;
+            self.init_to_source_vec = rotz(-detector_angle/2) * self.to_source_vec; % Change from center to edge
+            self.to_source_vec      = self.init_to_source_vec;                      % Change from center to edge
         end
 
         function self = rotate(self)
             % rotate the detector by the rotation angle
-            self.init_to_source_vec = self.rot_mat * self.init_to_source_vec;
-            self.source_position    = self.rot_mat * self.source_position;
+            self.to_source_vec   = self.rot_mat * self.to_source_vec;
+            self.source_position = self.rot_mat * self.source_position;
         end
 
         function ray_generator = get_ray_generator(self, ray_per_pixel)
@@ -42,7 +44,7 @@ classdef curved_detector < detector
             pixel_angle      = self.pixel_angle;
             dist_to_detector = self.dist_to_detector;
             num_pixels       = self.num_pixels;
-            to_source_vec    = rotz(pixel_angle / 2) * self.init_to_source_vec;
+            to_source_vec    = rotz(pixel_angle / 2) * self.to_source_vec;
             source_pos       = self.source_position;
 
             % Create the function which returns the rays
@@ -53,7 +55,42 @@ classdef curved_detector < detector
                 xray = ray(source_pos, -pixel_vec, dist_to_detector);
             end
         end
-                
+        function pixel_generator = get_pixel_generator(self, angle_index, ray_per_pixel)
+            % Create a function which returns the rays which should be fired to hit each pixel.
+            % Only 1 ray per pixel is supported at the moment, as anti-aliasing techniques are not yet implemented.
+            arguments
+                self           curved_detector
+                angle_index    double
+                ray_per_pixel  int32             = 1
+            end
+            assert(nargin==2, "Only 1 ray per pixel is supported at the moment, as anti-aliasing techniques are not yet implemented.")
+            
+            % Cache some variables to make the function faster
+            pixel_angle      = self.pixel_angle;
+            dist_to_detector = self.dist_to_detector;
+            num_pixels       = self.num_pixels;
+            detector_response= @self.detector_response;
 
+            if angle_index == 1
+                rot_mat = eye(3); 
+                rot_mat_edge = rotz(pixel_angle / 2); % Change from center of pixel to edge of pixel
+            else
+                cur_angle = self.rot_angle * (angle_index - 1);
+                rot_mat = rotz(cur_angle);
+                rot_mat_edge = rotz(pixel_angle / 2 + cur_angle);
+            end
+
+            to_source_vec = rot_mat_edge * self.init_to_source_vec;
+            source_pos    = rot_mat * self.init_source_pos;
+
+            % Create the function which returns the rays
+            pixel_generator = @generator;
+            function pixel_value = generator(pixel, voxels)
+                assert(pixel <= num_pixels && pixel > 0, "Pixel number must be between 1 and the number of pixels on the detector.")
+                pixel_vec = rotz(pixel_angle * (pixel - 1)) * to_source_vec;
+                xray = ray(source_pos, -pixel_vec, dist_to_detector);
+                pixel_value = detector_response(xray.calculate_mu(voxels));
+            end
+        end
     end
 end

--- a/src/classes/parallel_detector.m
+++ b/src/classes/parallel_detector.m
@@ -1,11 +1,14 @@
 classdef parallel_detector < detector
    
     properties
-        centre           (3, 1) double
-        corner           (3, 1) double
-        width            (1, 1) double
-        pixel_width      (1, 1) double        
-        detector_vec     (3, 1) double = [1;0;0] % Vector from left to right corner of detector
+        init_centre       (3, 1) double
+        centre            (3, 1) double
+        init_corner       (3, 1) double
+        corner            (3, 1) double
+        width             (1, 1) double
+        pixel_width       (1, 1) double        
+        init_detector_vec (3, 1) double = [1;0;0] % Vector from left to right corner of detector
+        detector_vec      (3, 1) double = [1;0;0] % Vector from left to right corner of detector
     end
 
     methods
@@ -22,7 +25,9 @@ classdef parallel_detector < detector
             
             % Only true for initial configuration
             self.centre = self.to_source_vec * -dist_to_detector/2;
+            self.init_centre = self.centre;
             self.corner = self.centre - self.detector_vec * self.width/2;
+            self.init_corner = self.corner;
         end
 
         function self = rotate(self) % How can I make this fast?
@@ -59,6 +64,39 @@ classdef parallel_detector < detector
                 pixel_centre = corner + detector_vec .* (pixel - 0.5) * pixel_width;
                 source_position = pixel_centre + to_source_vec * dist_to_detector;
                 xray = ray(source_position, -to_source_vec, dist_to_detector);
+            end
+        end
+        function pixel_generator = get_pixel_generator(self, angle_index, ray_per_pixel)
+            % Create a function which returns the rays which should be fired to hit each pixel.
+            % Only 1 ray per pixel is supported at the moment, as anti-aliasing techniques are not yet implemented.
+            arguments
+                self           parallel_detector
+                angle_index    double
+                ray_per_pixel  int32             = 1
+            end
+            assert(nargin==2, "Only 1 ray per pixel is supported at the moment, as anti-aliasing techniques are not yet implemented.")
+            
+            if angle_index == 1; rot_mat = eye(3);
+            else;                rot_mat = rotz(self.rot_angle * (angle_index - 1));
+            end
+            detector_vec  = rot_mat * self.init_detector_vec;
+            to_source_vec = rot_mat * self.init_to_source_vec;
+            corner        = rot_mat * self.init_centre - detector_vec.*self.width/2;
+
+            % Cache some variables to make the function faster
+            pixel_width      = self.pixel_width;
+            dist_to_detector = self.dist_to_detector;
+            num_pixels       = self.num_pixels;
+            detector_response= @self.detector_response;
+
+            % Create the function which returns the rays
+            pixel_generator = @generator;
+            function pixel_value = generator(pixel, voxels)
+                assert(pixel <= num_pixels && pixel > 0, "Pixel number must be between 1 and the number of pixels on the detector.")
+                pixel_centre = corner + detector_vec .* (pixel - 0.5) * pixel_width;
+                source_position = pixel_centre + to_source_vec * dist_to_detector;
+                xray = ray(source_position, -to_source_vec, dist_to_detector);
+                pixel_value = detector_response(xray.calculate_mu(voxels));
             end
         end
     end

--- a/src/classes/voxel_array.m
+++ b/src/classes/voxel_array.m
@@ -27,8 +27,12 @@ classdef voxel_array
             obj.get_voxel_mu = get_voxel_mu;
         end
 
-        function position = get_point_position(obj, i, j, k)
-            position = obj.array_position + ([i; j; k] - 1) .* obj.dimensions;
+        function position = get_point_position(obj, indices)
+            position = obj.array_position + (indices - 1) .* obj.dimensions;
+        end
+
+        function position = get_points_position(obj, i, j, k)
+            position = obj.array_position + ([i;j;k] - 1) .* obj.dimensions;
         end
 
         function plane = get_single_coord(obj, coord, index)
@@ -39,7 +43,7 @@ classdef voxel_array
 
         function mu = get_mu(obj, i, j, k)
             % Convert indices to position at centre of voxel
-            position = obj.get_point_position(i, j, k) + obj.dimensions ./ 2;
+            position = obj.get_point_position([i; j; k]) + obj.dimensions ./ 2;
 
             % Get mu at position
             mu = obj.get_voxel_mu(position(1, :), position(2, :), position(3, :));

--- a/tests/detector_tests.m
+++ b/tests/detector_tests.m
@@ -13,27 +13,27 @@ classdef detector_tests < matlab.unittest.TestCase
         function test_curved_init(tc)
             % detector = curved_detector(9, 18, pi/180, pi/2); % using detector width
             detector = curved_detector(9, pi, pi/180, pi/2);
-            tc.verifyEqual(detector.init_to_source_vec, [1; 0; 0], 'AbsTol', 1e-15);
+            tc.verifyEqual(detector.init_source_pos, detector.source_position, 'AbsTol', 1e-15);
             tc.verifyEqual(detector.source_position, [0; 4.5; 0], 'AbsTol', 1e-15);
             tc.verifyEqual(detector.pixel_angle, pi/180);
 
             detector = detector.rotate();
-            tc.verifyEqual(detector.init_to_source_vec, [0; 1; 0], 'AbsTol', 1e-15);
+            tc.verifyEqual(detector.init_source_pos, [0; 4.5; 0], 'AbsTol', 1e-15);
             tc.verifyEqual(detector.source_position, [-4.5; 0; 0], 'AbsTol', 1e-15);
             tc.verifyEqual(detector.pixel_angle, pi/180);
 
             detector = curved_detector(9, pi, pi/180);
             detector = detector.rotate();
-            tc.verifyEqual(detector.init_to_source_vec, rotz(pi/180)*[1; 0; 0], 'AbsTol', 1e-15);
+            tc.verifyEqual(detector.source_position, 4.5*rotz(pi/2 + pi/180)*[1; 0; 0], 'AbsTol', 1e-15);
 
             % detector = curved_detector(11, 11, pi/30, pi/4); % using detector width
             detector = curved_detector(11, pi/3, pi/30, pi/4);
-            tc.verifyEqual(detector.init_to_source_vec, rotz(-pi/6)*[0; 1; 0], 'AbsTol', 1e-15);
+            tc.verifyEqual(detector.init_source_pos, detector.source_position, 'AbsTol', 1e-15);
             tc.verifyEqual(detector.source_position, [0; 5.5; 0], 'AbsTol', 1e-15);
             tc.verifyEqual(detector.pixel_angle, pi/30);
             
             detector = detector.rotate();
-            tc.verifyEqual(detector.init_to_source_vec, rotz(pi/4)*(rotz(-pi/6)*[0; 1; 0]), 'AbsTol', 1e-15);
+            tc.verifyEqual(detector.init_source_pos, [0; 5.5; 0], 'AbsTol', 1e-15);
             tc.verifyEqual(detector.source_position, rotz(pi/4)*[0; 5.5; 0], 'AbsTol', 1e-15); 
             tc.verifyEqual(detector.pixel_angle, pi/30);
         end
@@ -125,6 +125,33 @@ classdef detector_tests < matlab.unittest.TestCase
             tc.verifyEqual(image(:, 2), [1-2*sq2/3;1-sq2/3;1;1-sq2/3;1-2*sq2/3], 'AbsTol', 1e-15);
             tc.verifyEqual(image(:, 3), [0;1/sq2;1/sq2;1/sq2;0], 'AbsTol', 1e-15);
             tc.verifyEqual(image(:, 4), [1-2*sq2/3;1-sq2/3;1;1-sq2/3;1-2*sq2/3], 'AbsTol', 1e-15);
+        end
+
+        function test_generate_image_p(tc)
+            detector = parallel_detector(10, 5, 1, pi/4);
+            my_box = voxel_box([0;0;0], [3;3;3]);
+            array = voxel_array(zeros(3, 1), [5; 5; 5], 1, my_box);
+            sq2 = sqrt(2);
+            
+            image = detector.generate_image_p(array);
+            tc.verifyEqual(size(image), [5, 4]);
+            tc.verifyEqual(image(:, 1), [0;1/sq2;1/sq2;1/sq2;0], 'AbsTol', 1e-15);
+            tc.verifyEqual(image(:, 2), [1-2*sq2/3;1-sq2/3;1;1-sq2/3;1-2*sq2/3], 'AbsTol', 1e-15);
+            tc.verifyEqual(image(:, 3), [0;1/sq2;1/sq2;1/sq2;0], 'AbsTol', 1e-15);
+            tc.verifyEqual(image(:, 4), [1-2*sq2/3;1-sq2/3;1;1-sq2/3;1-2*sq2/3], 'AbsTol', 1e-15);
+        end
+
+        function test_curved_generate_image_p(tc)
+            dist_to_detector = 10;
+            detector_angle = pi/20;
+            pixel_angle = detector_angle/500;
+            rotation_angle = pi/8;
+            detector = curved_detector(dist_to_detector, detector_angle, pixel_angle, rotation_angle);
+            my_box = voxel_box([0;0;0], [3;3;3]);
+            array = voxel_array(zeros(3, 1), [5; 5; 5], 1, my_box);
+            image = detector.generate_image(array);
+            image_p = detector.generate_image_p(array);
+            tc.verifyEqual(image_p, image, 'AbsTol', 1e-14)
         end
     end
 end

--- a/tests/ray_tests.m
+++ b/tests/ray_tests.m
@@ -8,44 +8,41 @@ classdef ray_tests < matlab.unittest.TestCase
         % Setup for each test
     end
 
-    methods (Test)
-        % Test methods
-        function test_ray_init(tc)
-            r = ray([0;0;0], [1;0;0], 10);
-            tc.assertEqual(r.start_point, [0;0;0]);
-            tc.assertEqual(r.direction, [1;0;0]);
-            tc.assertEqual(r.end_point, [10;0;0]);
-            tc.assertEqual(r.energy, 1); % default energy - will change later
-
-            r2 = ray([0;-5;0], [0;1;0], 10);
-            tc.assertEqual(r2.start_point, [0;-5;0]);
-            tc.assertEqual(r2.direction, [0;1;0]);
-            tc.assertEqual(r2.end_point, [0;5;0]);
-            tc.assertEqual(r2.energy, 1); % default energy - will change later
-        end
-
-        function test_get_intersections(tc)
+    methods
+        function gen_get_intersections(tc, ray)
             my_box = voxel_box([0;0;0], [3;3;3]);
             array = voxel_array(zeros(3, 1), [5; 5; 5], 1, my_box);
             threes = zeros(3, 5) + 3;
             
             r = ray([-6;0;0], [1;0;0], 12);
             [lengths, indices] = r.get_intersections(array);
-
             exp = threes; exp(1, :) = [1, 2, 3, 4, 5];
-            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 1e-15);
+            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 2e-15);
             tc.assertEqual(indices, exp);
 
             r = ray([0;-6;0], [0;1;0], 12);
             [lengths, indices] = r.get_intersections(array);
             exp = threes; exp(2, :) = [1, 2, 3, 4, 5];
-            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 1e-15);
+            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 2e-15);
             tc.assertEqual(indices, exp);
 
             r = ray([0;0;-6], [0;0;1], 12);
             [lengths, indices] = r.get_intersections(array);
             exp = threes; exp(3, :) = [1, 2, 3, 4, 5];
-            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 1e-15);
+            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 2e-15);
+            tc.assertEqual(indices, exp);
+
+            r = ray([-6;-6;0], [1;1;0], 20);
+            [lengths, indices] = r.get_intersections(array);
+            exp = threes; exp(2, :) = [1, 2, 3, 4, 5]; exp(1, :) = [1, 2, 3, 4, 5];
+            s2 = sqrt(2);
+            tc.assertEqual(lengths, [s2, s2, s2, s2, s2], 'AbsTol', 2e-15);
+            tc.assertEqual(indices, exp);
+
+            r = ray([0;0;-6], [0;0;1], 12);
+            [lengths, indices] = r.get_intersections(array);
+            exp = threes; exp(3, :) = [1, 2, 3, 4, 5];
+            tc.assertEqual(lengths, [1, 1, 1, 1, 1], 'AbsTol', 2e-15);
             tc.assertEqual(indices, exp);
 
             r = ray([6;6;6], [-1;-1;-1], 22); % 3D diagonal backwards
@@ -63,6 +60,27 @@ classdef ray_tests < matlab.unittest.TestCase
             [lengths, indices] = r.get_intersections(array);
             tc.assertEqual(lengths, []);
             tc.assertEqual(indices, []);
+        end
+    end
+
+    methods (Test)
+        % Test methods
+        function test_ray_init(tc)
+            r = ray([0;0;0], [1;0;0], 10);
+            tc.assertEqual(r.start_point, [0;0;0]);
+            tc.assertEqual(r.direction, [1;0;0]);
+            tc.assertEqual(r.end_point, [10;0;0]);
+            tc.assertEqual(r.energy, 1); % default energy - will change later
+
+            r2 = ray([0;-5;0], [0;1;0], 10);
+            tc.assertEqual(r2.start_point, [0;-5;0]);
+            tc.assertEqual(r2.direction, [0;1;0]);
+            tc.assertEqual(r2.end_point, [0;5;0]);
+            tc.assertEqual(r2.energy, 1); % default energy - will change later
+        end
+
+        function test_siddon_ray(tc)
+            tc.gen_get_intersections(@ray);
         end
 
         function test_calculate_mu(tc)

--- a/tests/voxel_array_tests.m
+++ b/tests/voxel_array_tests.m
@@ -47,28 +47,28 @@ classdef voxel_array_tests < matlab.unittest.TestCase
 
         function test_get_point_position(tc)
             % Verify get_point_position
-            tc.verifyEqual(tc.test_obj1.get_point_position(1, 1, 1), [-5; -5; -5]);
-            tc.verifyEqual(tc.test_obj1.get_point_position(1, 2, 3), [-5; -4; -3]);
-            tc.verifyEqual(tc.test_obj1.get_point_position(11, 10, 9), [5; 4; 3]);
-            tc.verifyEqual(tc.test_obj1.get_point_position(...
+            tc.verifyEqual(tc.test_obj1.get_point_position([1; 1; 1]), [-5; -5; -5]);
+            tc.verifyEqual(tc.test_obj1.get_point_position([1; 2; 3]), [-5; -4; -3]);
+            tc.verifyEqual(tc.test_obj1.get_point_position([11; 10; 9]), [5; 4; 3]);
+            tc.verifyEqual(tc.test_obj1.get_points_position(...
             [1, 1, 11], [1, 2, 10], [1, 3, 9]), [-5, -5, 5; -5, -4, 4; -5, -3, 3;]);
             
-            tc.verifyEqual(tc.test_obj2.get_point_position(1, 1, 1), [-5; -5; -5]);
-            tc.verifyEqual(tc.test_obj2.get_point_position(1, 2, 3), [-5; -4.5; -4]);
-            tc.verifyEqual(tc.test_obj2.get_point_position(21, 20, 19), [5; 4.5; 4]);
-            tc.verifyEqual(tc.test_obj2.get_point_position(...
+            tc.verifyEqual(tc.test_obj2.get_point_position([1; 1; 1]), [-5; -5; -5]);
+            tc.verifyEqual(tc.test_obj2.get_point_position([1; 2; 3]), [-5; -4.5; -4]);
+            tc.verifyEqual(tc.test_obj2.get_point_position([21; 20; 19]), [5; 4.5; 4]);
+            tc.verifyEqual(tc.test_obj2.get_points_position(...
             [1, 1, 21], [1, 2, 20], [1, 3, 19]), [-5, -5, 5; -5, -4.5, 4.5; -5, -4, 4;]);
 
-            tc.verifyEqual(tc.test_obj3.get_point_position(1, 1, 1), [-5; -5; -5]);
-            tc.verifyEqual(tc.test_obj3.get_point_position(1, 2, 3), [-5; -4; -3]);
-            tc.verifyEqual(tc.test_obj3.get_point_position(10, 9, 8), [4; 3; 2]);
-            tc.verifyEqual(tc.test_obj3.get_point_position(...
+            tc.verifyEqual(tc.test_obj3.get_point_position([1; 1; 1]), [-5; -5; -5]);
+            tc.verifyEqual(tc.test_obj3.get_point_position([1; 2; 3]), [-5; -4; -3]);
+            tc.verifyEqual(tc.test_obj3.get_point_position([10; 9; 8]), [4; 3; 2]);
+            tc.verifyEqual(tc.test_obj3.get_points_position(...
             [1, 1, 10], [1, 2, 9], [1, 3, 8]), [-5, -5, 4; -5, -4, 3; -5, -3, 2;]);
 
-            tc.verifyEqual(tc.test_obj4.get_point_position(1, 1, 1), [0; -1; -4.5]);
-            tc.verifyEqual(tc.test_obj4.get_point_position(1, 2, 3), [0; 0; -2.5]);
-            tc.verifyEqual(tc.test_obj4.get_point_position(10, 9, 8), [9; 7; 2.5]);
-            tc.verifyEqual(tc.test_obj4.get_point_position(...
+            tc.verifyEqual(tc.test_obj4.get_point_position([1; 1; 1]), [0; -1; -4.5]);
+            tc.verifyEqual(tc.test_obj4.get_point_position([1; 2; 3]), [0; 0; -2.5]);
+            tc.verifyEqual(tc.test_obj4.get_point_position([10; 9; 8]), [9; 7; 2.5]);
+            tc.verifyEqual(tc.test_obj4.get_points_position(...
             [1, 1, 10], [1, 2, 9], [1, 3, 8]), [0, 0, 9; -1, 0, 7; -4.5, -2.5, 2.5;]);
         end
 
@@ -97,10 +97,10 @@ classdef voxel_array_tests < matlab.unittest.TestCase
             for i = 1:3
                 for j = 10:12
                     for k = 5:7
-                        ijk1 = tc.test_obj1.get_point_position(i, j, k) + tc.test_obj1.dimensions/2;
-                        ijk2 = tc.test_obj2.get_point_position(i, j, k) + tc.test_obj2.dimensions/2;
-                        ijk3 = tc.test_obj3.get_point_position(i, j, k) + tc.test_obj3.dimensions/2;
-                        ijk4 = tc.test_obj4.get_point_position(i, j, k) + tc.test_obj4.dimensions/2;
+                        ijk1 = tc.test_obj1.get_point_position([i; j; k]) + tc.test_obj1.dimensions/2;
+                        ijk2 = tc.test_obj2.get_point_position([i; j; k]) + tc.test_obj2.dimensions/2;
+                        ijk3 = tc.test_obj3.get_point_position([i; j; k]) + tc.test_obj3.dimensions/2;
+                        ijk4 = tc.test_obj4.get_point_position([i; j; k]) + tc.test_obj4.dimensions/2;
 
                         tc.verifyEqual(tc.test_obj1.get_mu(i, j, k), ijk1(1) + ijk1(2) + ijk1(3));
                         tc.verifyEqual(tc.test_obj2.get_mu(i, j, k), ijk2(1) + ijk2(2) + ijk2(3));


### PR DESCRIPTION
- Add function to rays `get_pixel_generator` to do a little more than the `get_ray_generator` (for parallelised detection)
- Simplify ray tracing function 
- Add function taking a vector to get point position in the voxel array
- Update and improve tests